### PR TITLE
Parse spikes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Greg Hale <imalsogreg@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+clap   = "2.33.0"
+chrono = "0.4.7"
 
 [lib]
 name = "xcrust"
@@ -12,3 +14,6 @@ src  = "src/lib.rs"
 
 [[bin]]
 name = "xcrust-hello"
+
+[[bin]]
+name = "xcrust-cat-spikes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2018"
 [dependencies]
 clap   = "2.33.0"
 chrono = "0.4.7"
+failure = "0.1.5"
+nom = "5.0.0"
+num = "0.2.0"
+num-traits = "0.2.8"
+num-derive = "0.2.5"
 
 [lib]
 name = "xcrust"

--- a/src/bin/xcrust-cat-spikes.rs
+++ b/src/bin/xcrust-cat-spikes.rs
@@ -1,17 +1,14 @@
-// use std::io;
-// use std::fs::{File};
-// use std::io::prelude::*;
+use std::io::prelude::*;
 
-use xcrust::mwl_ad::{read_spikes};
+use std::io::stdin;
+use xcrust::spike::mwl_ad::{read_spikes};
+use xcrust::spike::ascii_draw;
 use chrono::Duration;
 
 use clap::{crate_version, App, Arg, arg_enum, value_t};
 use clap as Clap;
 
 use std::collections::HashMap;
-// use std::env;
-// use std::error::Error;
-// use std::fmt;
 use std::path::{PathBuf};
 
 /// Required config for the main conversion command
@@ -40,6 +37,7 @@ arg_enum!{
 enum OutputFormat {
     SpikeDebug,
     SpikeJSON,
+    SpikeAscii,
 }
 }
 
@@ -49,8 +47,20 @@ fn main() {
     // File::open(config.input_file).unwrap().read(&mut b).unwrap();
     // println!("config: {:?}", config);
     
-    println!("b: {:?}", read_spikes(config.input_file.as_path()));
+    // println!("b: {:?}", read_spikes(config.input_file.as_path()));
+    let spikes = read_spikes( config.input_file.to_str().unwrap() );
+    match config.output_format {
+        OutputFormat::SpikeDebug => println!("spikes: {:?}", spikes),
+        OutputFormat::SpikeJSON => panic!("not implemented"),
+        OutputFormat::SpikeAscii => for s in spikes {
+            let plot = ascii_draw::DEFAULT_PLOT;
+            ascii_draw::draw_spike(plot, &s.waveforms);
+            let _ = stdin().read(&mut [0u8]).unwrap();
+        },
+        
+    }
 }
+
 
 
 fn input_format(

--- a/src/bin/xcrust-cat-spikes.rs
+++ b/src/bin/xcrust-cat-spikes.rs
@@ -1,16 +1,18 @@
-use xcrust::spike::mwl_ad::*;
-// use xcrust::version::*;
-use chrono::Duration;
+// use std::io;
+// use std::fs::{File};
+// use std::io::prelude::*;
 
+use xcrust::mwl_ad::{read_spikes};
+use chrono::Duration;
 
 use clap::{crate_version, App, Arg, arg_enum, value_t};
 use clap as Clap;
 
 use std::collections::HashMap;
-use std::env;
-use std::error::Error;
-use std::fmt;
-use std::path::{Path, PathBuf};
+// use std::env;
+// use std::error::Error;
+// use std::fmt;
+use std::path::{PathBuf};
 
 /// Required config for the main conversion command
 #[derive(Clone, Debug)]
@@ -21,13 +23,6 @@ struct ConvertConfig {
     after: Option<Duration>,
     before: Option<Duration>,
 }
-
-#[derive(Debug)]
-enum ConfigError {
-    NoInputFormat,
-    NoOutputFormat,
-}
-
 
 
 arg_enum!{
@@ -49,8 +44,12 @@ enum OutputFormat {
 }
 
 fn main() {
-    let config = parse_config();
-    println!("config: {:?}", config);
+    let config = parse_config().unwrap_or_else(|_| panic!("TODO"));
+    // let mut b = [0; 10];
+    // File::open(config.input_file).unwrap().read(&mut b).unwrap();
+    // println!("config: {:?}", config);
+    
+    println!("b: {:?}", read_spikes(config.input_file.as_path()));
 }
 
 
@@ -85,7 +84,7 @@ fn input_format(
 }
 
 
-fn parse_config() -> Result<ConvertConfig, ConfigError> {
+fn parse_config() -> Result<ConvertConfig, String> {
 
     // Specify commandline interface
     let matches = App::new("xcrust-cat-spikes")

--- a/src/bin/xcrust-cat-spikes.rs
+++ b/src/bin/xcrust-cat-spikes.rs
@@ -1,0 +1,142 @@
+use xcrust::spike::mwl_ad::*;
+// use xcrust::version::*;
+use chrono::Duration;
+
+
+use clap::{crate_version, App, Arg, arg_enum, value_t};
+use clap as Clap;
+
+use std::collections::HashMap;
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Required config for the main conversion command
+#[derive(Clone, Debug)]
+struct ConvertConfig {
+    input_file: PathBuf,
+    input_format: InputFormat,
+    output_format: OutputFormat,
+    after: Option<Duration>,
+    before: Option<Duration>,
+}
+
+#[derive(Debug)]
+enum ConfigError {
+    NoInputFormat,
+    NoOutputFormat,
+}
+
+
+
+arg_enum!{
+/// We support only one input format for now: mwl ad .tt file
+#[derive(Clone, Debug)]
+enum InputFormat {
+    Ad,
+}
+}
+
+arg_enum!{
+/// We support only one output format for now: the
+/// debugging format of `Spike`
+#[derive(Clone, Debug)]
+enum OutputFormat {
+    SpikeDebug,
+    SpikeJSON,
+}
+}
+
+fn main() {
+    let config = parse_config();
+    println!("config: {:?}", config);
+}
+
+
+fn input_format(
+    input_type: Option<InputFormat>,
+    input_file_ext: Option<&str>,
+) -> InputFormat {
+    input_type.unwrap_or_else(
+        || match input_file_ext {
+            None => (Clap::Error::with_description(
+                "Must specify an --input-format, or use a \
+                 file with a known extension",
+                Clap::ErrorKind::ValueValidation
+            )).exit(),
+            Some(input_ext) => {
+                let mut extension_formats: HashMap<&str, InputFormat> =
+                    HashMap::new();
+                extension_formats.insert("tt", InputFormat::Ad);
+                extension_formats
+                    .get(input_ext)
+                    .unwrap_or_else(|| Clap::Error::with_description(
+                        format!("Extension {} is not in the list \
+                                 of known extensions: {:?}. Please use \
+                                 --input-format",
+                                input_ext,
+                                extension_formats.keys()
+                        ).as_str(),
+                        Clap::ErrorKind::ValueValidation).exit())
+                    .clone()
+            }
+        })
+}
+
+
+fn parse_config() -> Result<ConvertConfig, ConfigError> {
+
+    // Specify commandline interface
+    let matches = App::new("xcrust-cat-spikes")
+        .version(crate_version!())
+        .arg(Arg::from_usage("<input-file> 'File to read spikes from'"))
+        .arg(Arg::from_usage("-i, --input-format [input-format] \
+                              'Input file format (leave unset to infer from FILE)'")
+             .possible_values(&InputFormat::variants()))
+        .arg(Arg::from_usage("-o, --output-format [output-format] \
+                              'Output file format'")
+             .possible_values(&OutputFormat::variants()))
+        .arg(Arg::from_usage("-a --after [after] 'Lower bound on spikes to cat'"))
+        .arg(Arg::from_usage("-b --before [before] 'Upper bound on spikes to cat'"))
+        .get_matches();
+
+    // Parse out the parts needed for inferring the input-format
+    let input_file = value_t!(matches, "input-file", PathBuf).unwrap();
+    let file_ext = input_file.extension().and_then(|p| p.to_str());
+    let input_format_arg = map_well_formed(
+        value_t!(matches, "input-format", InputFormat),
+        |f| f
+    );
+
+    // Parse input and output formats
+    let input_format = input_format(input_format_arg, file_ext);
+    let output_format = value_t!(matches, "output-format", OutputFormat)
+        .unwrap_or(OutputFormat::SpikeDebug);
+
+    fn map_well_formed<F,A,B>(r: Result<A, Clap::Error>, f: F) -> Option<B>
+    where
+        F: Fn(A) -> B,
+    {
+        match r {
+            Ok  (a) => Some(f(a)),
+            Err (Clap::Error { kind: Clap::ErrorKind::ArgumentNotFound, .. } ) => None,
+            Err (e) => e.exit(),
+        }
+    }
+
+    fn get_duration(r : Result<f64, Clap::Error>) -> Option<Duration> {
+        map_well_formed( r, |t| Duration::nanoseconds( (t * 1_000_000_000.0) as i64) )
+    }
+    
+    let after = get_duration(value_t!(matches, "after", f64));
+    let before = get_duration(value_t!(matches, "before", f64));
+
+    Ok(ConvertConfig {
+        input_file: input_file.to_path_buf(),
+        input_format: input_format.clone(),
+        output_format,
+        after,
+        before,
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,18 @@
+#[macro_use] extern crate num;
+#[macro_use] extern crate num_derive;
+#[macro_use] extern crate failure;
 pub mod spike;
+pub mod mwl_ad;
+
+pub fn hi(x : i32) -> i32 {
+    x + 1
+}
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     #[test]
     fn it_works() {
-        assert_eq!(2 + 2, 4);
+        assert_eq!(hi(3), 4);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod spike;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/mwl_ad/header.rs
+++ b/src/mwl_ad/header.rs
@@ -1,0 +1,298 @@
+use std::str;
+use nom::{ IResult };
+use nom;
+use nom::bytes::complete as noms;
+use nom::sequence::{delimited};
+use nom::multi::{separated_list};
+use nom::branch;
+use nom::combinator;
+use nom::sequence;
+
+// TODO: I want to specify that this is the _real_ public API,
+// and that everything below `require` is only public in case
+// someone downstream really needs it.
+//
+// How do you format documentation in rust?
+
+/// Errors related to header file parsing and key lookup
+#[derive (Clone, Debug, PartialEq)]
+pub enum HeaderError {
+    UnknownKey { key: String },
+    ParseError { err: String },
+}
+
+/// Abstract metadata collection derived from file header
+pub struct Metadata <'a> {
+    pub header: Vec<HeaderLine<'a>>
+}
+
+/// Parse Metadata and get a pointer to the file's binary data
+pub fn parse(file_contents: &str) -> Result<(Metadata, &str), HeaderError> {
+    match parse_header(file_contents) {
+        Ok ((file_data, lines)) =>
+            Ok ((Metadata { header: lines }, file_data)),
+        Err (e) =>
+            Err (HeaderError::ParseError {
+                err: format!("header parse error: {:?}", e)
+            }),
+    }
+}
+
+/// Find the value for the first occurrance of `key` in the metadata
+pub fn lookup<'a, 'b>(metadata: &Metadata<'a>, key: &'b str) -> Option<&'a str> {
+    metadata
+        .header
+        .iter()
+        .filter_map(|hl| match hl {
+            HeaderLine::HeaderPair { key: k , value: v }
+            if k == &key => Some (v.to_owned()),
+            _ => None,
+        })
+        .next()
+}
+
+
+/// Find the value of the first occurrance of `key` in metadata,
+/// returning an error if `key` is missing
+pub fn require<'a, 'b>(metadata: &Metadata<'a>, key: &'b str) -> Result<&'a str, HeaderError> {
+    lookup(metadata, key)
+        .map(|v| Ok(v))
+        .unwrap_or( Err (HeaderError::UnknownKey { key: key.to_owned() }) )
+}
+
+
+/// Find all values for `key` in metadata
+pub fn lookup_multiple<'a, 'b>(metadata: Metadata<'a>, key: &'b str) -> Vec<&'a str> {
+    metadata
+        .header
+        .into_iter()
+        .filter_map(|hl| match hl {
+            HeaderLine::HeaderPair { key: k, value: v} if k == key => Some (v),
+            _ => None
+        })
+        .collect()
+}
+
+
+pub fn parse_header(s : &str) -> IResult<&str, Vec<HeaderLine>> {
+    delimited( noms::tag("%%BEGINHEADER\n"),
+               separated_list( noms::tag("\n"), header_line ),
+               noms::tag("\n%%ENDHEADER\n")
+    )(s)
+}
+
+
+#[derive (Clone, Copy, Debug, PartialEq)]
+pub enum HeaderLine <'a> {
+    HeaderPair { key: & 'a str, value: & 'a str },
+    HeaderComment { comment: & 'a str },
+}
+
+
+fn header_line(line: &str) -> IResult<&str, HeaderLine> {
+    dbg!(branch::alt(
+        (sequence::preceded( noms::tag("% "), header_pair ) ,
+         header_comment)
+    )(line))
+    // sequence::preceded(
+    //     noms::tag("% "),
+    //     branch::alt( (header_pair, header_comment) )
+    // )(line)
+}
+
+// Parses like this:
+// "key : value" -> HeaderPair { key: "key", value: "value" }
+fn header_pair(line: &str) -> IResult<&str, HeaderLine> {
+    combinator::map(
+        sequence::separated_pair(
+            noms::take_while1(|ch| ch != ':' && ch != '\n'),
+            noms::tag(":"),
+            noms::take_while1(|ch| ch != '\n')
+        ),
+        |(k,v) : (&str, &str)| HeaderLine::HeaderPair {
+            key: k.trim(),
+            value: v.trim()
+        }
+    )(line)
+}
+
+// Parses like this:
+// "% Any: thing" -> HeaderComment {comment: "Any: thing"}
+// "%\n"          -> HeaderComment {comment: ""}
+// The ':' signifying Pair (as opposed to Comment) is handled
+// upstream of this parser, so we don't need to handle it here
+fn header_comment(line: &str) -> IResult<&str, HeaderLine> {
+    branch::alt(
+        (combinator::map(
+            sequence::preceded(noms::tag("% "), noms::take_while(|ch| ch != '\n')),
+            |s| HeaderLine::HeaderComment { comment: s }),
+         combinator::value(
+             HeaderLine::HeaderComment { comment: "" },
+             sequence::preceded(
+                 noms::tag("%"),
+                 combinator::peek( noms::tag("\n") )
+             )
+         )
+        )
+    )(line)
+}
+                                  
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_header_pair() {
+        assert_eq!(header_pair("key : value"),
+                   Ok(("", HeaderLine::HeaderPair { key: "key",
+                                                    value: "value" })
+                   )
+        );
+    }
+    #[test]
+    fn it_parses_header_comment() {
+        assert_eq!(header_comment("% Some comment"),
+                   Ok(("", HeaderLine::HeaderComment { comment: "Some comment" }))
+        );
+    }
+
+    #[test]
+    fn it_stops_after_header_pair() {
+        assert_eq!(header_line("% key: value\nleftover"),
+                   Ok(("\nleftover", HeaderLine::HeaderPair{key: "key", value: "value"}))
+        );
+    }
+
+    #[test]
+    fn it_stops_after_header_comment() { 
+        assert_eq!(header_line("% Some comment\nleftover"),
+                   Ok(("\nleftover", HeaderLine::HeaderComment{comment: "Some comment"}))
+        );
+    }
+
+    #[test]
+    fn it_parses_header_line_small () {
+        let r = parse_header(HEADER_FIXTURE_SMALL);
+        assert_eq!(
+            r.clone().map(|vs| vs.1[0]),
+            Ok (HeaderLine::HeaderPair { key: "Program", value: "./adextract"})
+        );
+        assert_eq!(
+            r.map(|vs| vs.1[1]),
+            Ok (HeaderLine::HeaderComment { comment: "Some comment" })
+        );
+    }
+
+    #[test]
+    fn it_parses_header_big () {
+        let (m,_) = parse(HEADER_FIXTURE).unwrap();
+        assert_eq!(lookup(&m, "Program"), Some("./adextract"));
+        assert_eq!(require(&m, "Argc"), Ok("8"));
+    }
+}
+
+const HEADER_FIXTURE_SMALL : &'static str = r#"%%BEGINHEADER
+% Program: 	./adextract
+% Some comment
+%
+% Program Version: 	1.18
+% Argc: 	8
+%%ENDHEADER
+"#;
+    
+const HEADER_FIXTURE : &'static str = r#"%%BEGINHEADER
+% Program: 	./adextract
+% Program Version: 	1.18
+% Argc: 	8
+% Argv[1] :	data/original.spk.raw
+% Argv[2] :	-eslen80
+% Argv[3] :	-t
+% Argv[4] :	-probe
+% Argv[5] :	0
+% Argv[6] :	-o
+% Argv[7] :	data/original.tt
+% Date: 	Mon Oct 22 16:49:04 2012
+% Directory: 	/home/stuart/src/mwl-svn-export/bin
+% Hostname: 	ubuntu
+% Architecture: 	i686
+% User: 	stuart ()
+% File type: 	Binary
+% Extraction type: 	tetrode waveforms
+% Probe: 	0
+% Fields: 	timestamp,8,4,1	waveform,2,2,128	
+%
+% Beginning of header from input file 'data/original.spk.raw'
+% mode: SPIKE
+% adversion: 		1.36b
+% rate: 		250000.000000
+% nelectrodes: 2
+% nchannels: 		8
+% nelect_chan: 		4
+% errors: 		0
+% disk_errors: 		0
+% dma_bufsize: 		24576
+% spikelen: 		32
+% spikesep: 		26
+% channel 0 ampgain: 	24994
+% channel 0 adgain: 	0
+% channel 0 filter: 	200
+% channel 0 threshold: 	425
+% channel 0 color: 		15
+% channel 0 offset: 	65
+% channel 0 contscale: 	0
+% channel 1 ampgain: 	24994
+% channel 1 adgain: 	0
+% channel 1 filter: 	200
+% channel 1 threshold: 	425
+% channel 1 color: 		14
+% channel 1 offset: 	122
+% channel 1 contscale: 	0
+% channel 2 ampgain: 	24994
+% channel 2 adgain: 	0
+% channel 2 filter: 	200
+% channel 2 threshold: 	425
+% channel 2 color: 		13
+% channel 2 offset: 	180
+% channel 2 contscale: 	0
+% channel 3 ampgain: 	24994
+% channel 3 adgain: 	0
+% channel 3 filter: 	200
+% channel 3 threshold: 	425
+% channel 3 color: 		12
+% channel 3 offset: 	238
+% channel 3 contscale: 	0
+% channel 4 ampgain: 	24994
+% channel 4 adgain: 	0
+% channel 4 filter: 	200
+% channel 4 threshold: 	325
+% channel 4 color: 		11
+% channel 4 offset: 	296
+% channel 4 contscale: 	0
+% channel 5 ampgain: 	24994
+% channel 5 adgain: 	0
+% channel 5 filter: 	200
+% channel 5 threshold: 	325
+% channel 5 color: 		10
+% channel 5 offset: 	353
+% channel 5 contscale: 	0
+% channel 6 ampgain: 	24994
+% channel 6 adgain: 	0
+% channel 6 filter: 	200
+% channel 6 threshold: 	325
+% channel 6 color: 		9
+% channel 6 offset: 	411
+% channel 6 contscale: 	0
+% channel 7 ampgain: 	24994
+% channel 7 adgain: 	0
+% channel 7 filter: 	200
+% channel 7 threshold: 	325
+% channel 7 color: 		8
+% channel 7 offset: 	469
+% channel 7 contscale: 	0
+% spike_size: 		264
+% fields: int electrode_num; long timestamp; int data[128]
+% End of header from input file 'data/original.spk.raw'
+%
+%%ENDHEADER
+"#;

--- a/src/mwl_ad/mod.rs
+++ b/src/mwl_ad/mod.rs
@@ -1,0 +1,48 @@
+pub mod header;
+
+use std::path::{Path};
+
+#[derive(Debug, FromPrimitive, PartialEq, ToPrimitive)]
+pub enum FormatType {
+    InvalidT = 0,
+    CharT    = 1,
+    ShortT   = 2,
+    IntT     = 3,
+    FloatT   = 4,
+    DoubleT  = 5,
+    FuncT    = 6,
+    FFuncT   = 7,
+    ULongT   = 8,
+    UnknownT = -1,
+}
+
+#[derive(Debug,Fail, PartialEq)]
+pub enum DecodingError {
+    #[fail(display = "invalid format code: {}", code)]
+    UnknownFormatType { code : i32 },
+}
+
+pub fn decode_type(i: i32) -> Result<FormatType,DecodingError> {
+    num::FromPrimitive::from_i32(i)
+        .map(Ok)
+        .unwrap_or(Err(DecodingError::UnknownFormatType {code: i}))
+}
+
+pub fn read_spikes(_fp: &Path) -> () {
+    unimplemented!()
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_type_int() {
+        assert_eq!(decode_type(3), Ok (FormatType::IntT));
+        assert_eq!(decode_type(-2), Err (DecodingError::UnknownFormatType {code: -2} ));
+        assert_eq!(decode_type(1), Ok (FormatType::CharT));
+        assert_eq!(decode_type(9), Err (DecodingError::UnknownFormatType {code: 9} ));
+    }
+
+}

--- a/src/mwl_ad/mod.rs
+++ b/src/mwl_ad/mod.rs
@@ -28,9 +28,6 @@ pub fn decode_type(i: i32) -> Result<FormatType,DecodingError> {
         .unwrap_or(Err(DecodingError::UnknownFormatType {code: i}))
 }
 
-pub fn read_spikes(_fp: &Path) -> () {
-    unimplemented!()
-}
 
 
 #[cfg(test)]

--- a/src/spike/ascii_draw.rs
+++ b/src/spike/ascii_draw.rs
@@ -1,0 +1,108 @@
+#[derive (Debug)]
+pub struct PlotSpec {
+    pub width  : u16,
+    pub height : u16,
+    pub v_low  : f32,
+    pub v_high : f32,
+}
+
+pub const DEFAULT_PLOT : PlotSpec = PlotSpec {
+    width:   16,
+    height:  20,
+    v_low:  -0.000_005,
+    v_high:  0.000_005,
+};
+
+
+pub fn draw_spike(plot: PlotSpec, waveforms: &Vec<Vec<f32>>) {
+
+    let n_channels = waveforms.len() as u16;
+    let n_samps    = waveforms[0].len() as u16;
+
+    // Total window width is the per-channel width, plus
+    // one padding per channel, plus a final single padding
+    let window_width  = (plot.width + 1) * n_channels + 1;
+    let window_height = plot.height + 2;
+
+    // Linear index for the r_th row and c_th column of matrix
+    // stored in a flat array
+    let row_col_ind = |(r,c) : (u16, u16)| ((r * window_width) + c) as usize;
+
+    // Precompute this ratio once for v_row
+    let v_range_inverse = 1.0/(plot.v_high - plot.v_low);
+
+    // The row for a voltage is the bottom row, less a number
+    // of rows proportional to (v - min)/(max - min) and the
+    // window height
+    let v_row =
+        |v : f32| { plot.height as u16 -
+                    ( (v - plot.v_low) *
+                       v_range_inverse *
+                       plot.height as f32) as u16 + 1};
+
+    // The column (within that channel's window) for a voltage is
+    // the index of its sample, times the ratio of window length
+    // to waveform length
+    let t_col = |t : u16| ( (t as f32 * plot.width as f32 /
+                             n_samps as f32) as u16);
+
+    // Initiate an empty character matrix
+    let pixel_count = row_col_ind((plot.height+2, window_width)) as usize;
+    let mut pixel = Vec::with_capacity( pixel_count );
+    for _ in 0..pixel_count {
+        pixel.push(' ');
+    }; 
+
+    // Draw the outer border
+    for r in 1..window_height-1 {
+        pixel[ row_col_ind((r,                0)) as usize ] = '║';
+        pixel[ row_col_ind((r, window_width - 1)) as usize ] = '║';
+    };
+    for c in 1..window_width-1 {
+        pixel[ row_col_ind((0,                 c)) as usize ] = '═';
+        pixel[ row_col_ind((window_height - 1, c)) as usize ] = '═';
+    };
+
+    // Draw the outer border corners
+    pixel[ row_col_ind((0,                               0)) ] = '╔';
+    pixel[ row_col_ind((0,                  window_width-1)) ] = '╗';
+    pixel[ row_col_ind((window_height-1,                 0)) ] = '╚';
+    pixel[ row_col_ind((window_height - 1,window_width - 1)) ] = '╝';
+    
+    // Draw the diveders between channels
+    for chan in 1..n_channels {
+        let col = chan * (plot.width + 1);
+        pixel [ row_col_ind((0,                 col)) ] = '╦';
+        pixel [ row_col_ind((window_height - 1, col)) ] = '╩';
+        for r in 1..window_height-1 {
+            pixel[ row_col_ind((r, col)) ] = '║';
+        };
+    }
+
+    // Draw the 0-voltage axis and the voltage traces
+    for chan in 0..n_channels {
+        let col0 = chan * (plot.width + 1)  + 1 ;
+        for c in 0..plot.width {
+            let row_0 = v_row(0.0);
+
+            pixel[ row_col_ind((row_0, c + col0)) ] = '-';
+
+        };
+        for c in 0..n_samps {
+            let row_v = v_row( waveforms[chan as usize][c as usize] );
+            let col_v = t_col(c);
+            pixel[ row_col_ind((row_v, col_v + col0)) ] = '*';
+        };
+    };
+
+    // Print the pixel buffer out to the shell
+    for r in 0..window_height {
+        let i0 = row_col_ind((r,           0));
+        let i1 = row_col_ind((r,window_width));
+        let bytes : &[char] = &pixel[i0..i1];
+        let s : String = bytes.into_iter().collect();
+        println!("{}", s);
+    };
+    
+
+}

--- a/src/spike/mod.rs
+++ b/src/spike/mod.rs
@@ -1,0 +1,29 @@
+use chrono::{DateTime, Duration, Utc};
+pub mod mwl_ad;
+
+/// A raw `Spike` is a set of waveforems and a timestamp
+/// The voltage and time parameters are both abstract,
+/// and can only be interpreted in a larger context.
+///
+/// The context for interpreting waveforms should be in
+/// the container for these `Spike`s - for instance, an AD
+/// spike file will provide the sampling rate and a function
+/// for converting a u8 into absolute voltage
+#[derive(Debug)]
+pub struct Spike<V, T> {
+    pub waveforms: Vec<Vec<V>>,
+    pub time: T,
+}
+
+/// A `SpikeSI` (Spike with SI units) provides some context
+/// to a spike: its waveforms are Voltages (in V) at the tips
+/// of the electrode (amplifier gain has been divided out)
+/// Its timestamp is the absolute UTC time of the triggering
+/// sample. If triggering is due to a specific channel, than
+/// channel is at index `triggering_channel`.
+pub struct SpikeSI {
+    pub si_spike: Spike<f64, DateTime<Utc>>,
+    pub si_sampling_period: Duration,
+    pub si_triggering_sample: u32,
+    pub si_triggering_channel: Option<u32>,
+}

--- a/src/spike/mod.rs
+++ b/src/spike/mod.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Duration, Utc};
 pub mod mwl_ad;
+pub mod ascii_draw;
 
 /// A raw `Spike` is a set of waveforems and a timestamp
 /// The voltage and time parameters are both abstract,

--- a/src/spike/mwl_ad.rs
+++ b/src/spike/mwl_ad.rs
@@ -1,4 +1,86 @@
-use super::Spike;
+use std::fs::{File};
+use std::io::Read;
+use std::str;
+
+use nom::{IResult};
+use nom::combinator as nomc;
+use nom::sequence as noms;
+use nom::multi as nomm;
+use nom::number::complete as nomnum;
+
+// use nom::combinator as nom;
+
+use super::{Spike, SpikeSI};
+// use super::mwl_ad;
+use crate::mwl_ad::header;
+
+
+
+#[derive (Debug)]
+struct Metadata {
+}
+
+pub fn read_spikes(file_path: &str) -> Vec<Spike<f32,f32>> {
+    let mut buffer = Vec::new();
+    File::open(file_path).unwrap().read_to_end(&mut buffer).unwrap();
+    let (header, file_binary) = header::parse(buffer.as_slice()).unwrap();
+    let probe_ind_0 = match header::require( &header, "Probe" ) {
+        Ok("0") => 0,
+        Ok("1") => 4,
+        Ok(s)   => panic!("Unknown probe: {}. It should be \"0\" or \"1\"", s ),
+        Err(s)  => panic!("error reading probe index: {:?}", s),
+    };
+
+    let gain = |n: i8| {
+        let key = format!("channel {} ampgain", n);
+        let gain_str : &str = header::require(&header, key.as_str()).unwrap();
+        gain_str.parse::<f32>().unwrap()
+    };
+    let gains = vec![gain(probe_ind_0),
+                     gain(probe_ind_0 + 1),
+                     gain(probe_ind_0 + 2),
+                     gain(probe_ind_0 + 3)];
+
+    let spikes = parse_spikes( gains, file_binary );
+    spikes.unwrap().1
+}
+
+
+
+fn parse_spikes(gains : Vec<f32>, input: &[u8]) -> IResult<&[u8], Vec<Spike<f32,f32>>> {
+    nomm::many0(
+    nomc::map(
+        noms::pair(
+            nomnum::le_i32, // unsigned long
+            nomm::count(nomnum::le_i16, 128)
+        ),
+        |(t,vs)| {
+            let time = t as f32 / 10_000.0;
+            // let scale_v = move |v : &i16| (*v as f32);
+            let voltages : Vec<f32> = vs
+                .into_iter()
+                .zip( gains.iter().cycle() )
+                .map(|(v,g)| (v as f32) / 32_768.0 * 5.0 / g )
+                .collect();
+
+            let mut waveforms : Vec<Vec<f32>> = Vec::new();
+            for _ in 0..4 {
+                waveforms.push (Vec::new());
+            }
+            for i in 0..voltages.len() {
+                let chan = i % 4;
+                waveforms[chan].push(voltages[i]);
+            };
+            // let waveforms : Vec<Vec<f32>> = vec![to_waveform((0,31)),
+            //                                      to_waveform((32,63)),
+            //                                      to_waveform((64,95)),
+            //                                      to_waveform((96,127))
+            // ];
+            Spike {time, waveforms}
+        }
+    ))(input)
+}
+
 
 pub fn placeholder() {
     let my_test_spike: Spike<u32, u32> = Spike {

--- a/src/spike/mwl_ad.rs
+++ b/src/spike/mwl_ad.rs
@@ -1,0 +1,9 @@
+use super::Spike;
+
+pub fn placeholder() {
+    let my_test_spike: Spike<u32, u32> = Spike {
+        waveforms: vec![vec![0, 1, 2]],
+        time: 1,
+    };
+    println!("hi. it's {:?}", my_test_spike);
+}


### PR DESCRIPTION
It works. In lieu of tests, here is a plotted spike

```
╔════════════════╦════════════════╦════════════════╦════════════════╗
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║   **           ║                ║                ║                ║
║   **           ║   **           ║   **           ║                ║
║  *  *          ║  *             ║  *  *          ║  ***           ║
║                ║  *  *          ║  *             ║ *   *      *   ║
║--*--*------****║-------------*--║-*---*-------***║------------****║
║**       **** * ║**   *   **** **║**         ** **║**   *     * *  ║
║      * *       ║ *    * **      ║      *****     ║*     ******    ║
║      ***       ║       **       ║                ║       **       ║
║                ║      **        ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
║                ║                ║                ║                ║
╚════════════════╩════════════════╩════════════════╩════════════════╝
```